### PR TITLE
Updated screeps-game-api to 0.21 to work with latest version of screeps-starter-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ categories = ["visualization"]
 name = "room_visual_ext"
 
 [dependencies]
-screeps-game-api = "0.10"
+screeps-game-api = "0.21.0"
+wasm-bindgen = "0.2.92"
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
Updated the cargo crates to use the latest screeps-game-api (at least, the latest on screeps-starter-rust bare clone) and wasm-bindgen